### PR TITLE
feat: add Black Friday integration

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -71,6 +71,7 @@ function define_constants() {
 	define( 'CHURCH_FSE_DEBUG', defined( 'WP_DEBUG' ) && WP_DEBUG === true );
 	define( 'CHURCH_FSE_DIR', trailingslashit( get_template_directory() ) );
 	define( 'CHURCH_FSE_URL', trailingslashit( get_template_directory_uri() ) );
+	define( 'CHURCH_FSE_PRODUCT_SLUG', basename( CHURCH_FSE_DIR ) );
 }
 
 /**

--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -54,6 +54,9 @@ class Admin {
 		add_action( 'activated_plugin', array( $this, 'after_wpfs_activation' ) );
 		add_action( 'wp_ajax_church_fse_dismiss_welcome_notice', array( $this, 'remove_welcome_notice' ) );
 		add_action( 'wp_ajax_church_fse_set_wpfp_ref', array( $this, 'set_wpfp_ref' ) );
+
+		add_action( 'admin_enqueue_scripts', array( $this, 'register_internal_page' ) );
+		add_filter( 'themeisle_sdk_blackfriday_data', array( $this, 'add_black_friday_data' ) );
 	}
 
 	/**
@@ -275,5 +278,47 @@ class Admin {
 		update_option( self::WPFP_REF, 'church-fse' );
 
 		wp_send_json_success();
+	}
+
+	/**
+	 * Add Black Friday data.
+	 *
+	 * @param array $configs The configuration array for the loaded products.
+	 *
+	 * @return array
+	 */
+	public function add_black_friday_data( $configs ) {
+		$config = $configs['default'];
+
+		// translators: %1$s - plugin name, %2$s - discount.
+		$message_template = __( 'Need to accept payments or donations? Try %1$s, built by the same team as your theme — now up to %2$s OFF, for a limited time only.', 'church-fse' );
+
+		$config['dismiss']  = true; // Note: Allow dismiss since it appears on `/wp-admin`.
+		$config['message']  = sprintf( $message_template, 'WP Full Pay', '70%' );
+		$config['sale_url'] = add_query_arg(
+			array(
+				'utm_term' => 'free',
+			),
+			tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/wpfp-bf', 'bfcm', 'church-fse' ) )
+		);
+
+		$configs[ CHURCH_FSE_PRODUCT_SLUG ] = $config;
+
+		return $configs;
+	}
+
+	/**
+	 * Register internal pages.
+	 *
+	 * @return void
+	 */
+	public function register_internal_page() {
+		$screen = get_current_screen();
+		
+		if ( ( 'dashboard' !== $screen->id && 'themes' !== $screen->id ) ) {
+			return;
+		}
+		
+		do_action( 'themeisle_internal_page', CHURCH_FSE_PRODUCT_SLUG, $screen->id );
 	}
 }


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Add Black Friday integration

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots 
<!-- if applicable -->


![CleanShot 2025-05-16 at 17 15 38@2x](https://github.com/user-attachments/assets/5ba14d69-62a0-4eb9-86df-970a5f0937ed)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- [USE THIS SDK VERSION as PLUGIN](https://github.com/Codeinwp/themeisle-sdk-main/pull/295#issuecomment-2858057844)
- Alter the date to fall into the Black Friday sales period.

You can use this hook to alternate it:

```php
add_filter(
	'themeisle_sdk_current_date',
	function() {
		return new DateTime( '2025-11-26' );
	}
);
```

<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->